### PR TITLE
Styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,14 @@ Upload apk found in ./ember-cordova/cordova/platforms/android/build/outputs/apk/
 
 ### CSS
 
-[Styleguide](http://cssguidelin.es/)
+#### Style guide
+
+We use a living style guide provided by [Ember Freestyle](http://ember-freestyle.com/). To view the style guide go to the freestyle route
+[http://localhost:4200/#/freestyle](http://localhost:4200/#/freestyle)
+
 
 #### Folder layout
+[Style guide](http://cssguidelin.es/)
 
 ```
 sass/

--- a/app/controllers/freestyle.js
+++ b/app/controllers/freestyle.js
@@ -1,0 +1,61 @@
+import Ember from 'ember';
+import FreestyleController from 'ember-freestyle/controllers/freestyle';
+
+const { inject } = Ember;
+
+export default FreestyleController.extend({
+  emberFreestyle: inject.service(),
+
+  /* BEGIN-FREESTYLE-USAGE fp:notes
+### A few notes regarding freestyle-palette
+
+- Accepts a colorPalette POJO like the one found in the freestyle.js blueprint controller
+- Looks very nice
+
+And another thing...
+
+###### Markdown note demonstrating prettified code
+
+```
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  // ...
+  colorPalette: {
+    'primary': {
+      'name': 'cyan',
+      'base': '#00bcd4'
+    },
+    'accent': {
+      'name': 'amber',
+      'base': '#ffc107'
+    }
+  }
+  // ...
+});
+```
+  END-FREESTYLE-USAGE */
+
+  colorPalette: {
+    'primary': {
+      'name': 'cyan',
+      'base': '#00bcd4'
+    },
+    'accent': {
+      'name': 'amber',
+      'base': '#ffc107'
+    },
+    'secondary': {
+      'name': 'greyish',
+      'base': '#b6b6b6'
+    },
+    'foreground': {
+      'name': 'blackish',
+      'base': '#212121'
+    },
+    'background': {
+      'name': 'white',
+      'base': '#ffffff'
+    }
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -25,7 +25,8 @@ AppRouter.map(function() {
       this.route('scoreboard');
     });
   });
-
+  
+  this.route('freestyle');
 });
 
 export default AppRouter;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -49,7 +49,7 @@
 
 // Misc
 @import 'general';
-
+@import 'ember-freestyle'; 
 
 
 

--- a/app/templates/freestyle.hbs
+++ b/app/templates/freestyle.hbs
@@ -1,0 +1,34 @@
+{{#freestyle-guide
+  title='Ember Freestyle'
+  subtitle='Living Style Guide'
+  }}
+
+  {{#freestyle-section name='Visual Style' as |section|}}
+
+    {{#freestyle-subsection name='Typography' section=section}}
+
+      {{#freestyle-usage 'typography-times' title='Times New Roman'}}
+        {{freestyle-typeface fontFamily='Times New Roman'}}
+      {{/freestyle-usage}}
+
+      {{#freestyle-usage 'typography-helvetica' title='Helvetica'}}
+        {{freestyle-typeface fontFamily='Helvetica'}}
+      {{/freestyle-usage}}
+
+    {{/freestyle-subsection}}
+
+    {{#freestyle-subsection name='Color' section=section}}
+
+      {{#freestyle-usage 'fp' title='Freestyle Palette' usageTitle='Usage'}}
+        {{freestyle-palette
+        colorPalette=colorPalette
+        title='Dummy App Color Palette'
+        description='This component displays the color palette specified in freestyle/palette.json'
+        }}
+      {{/freestyle-usage}}
+
+    {{/freestyle-subsection}}
+
+  {{/freestyle-section}}
+
+{{/freestyle-guide}}

--- a/app/templates/freestyle.hbs
+++ b/app/templates/freestyle.hbs
@@ -1,7 +1,15 @@
 {{#freestyle-guide
-  title='Ember Freestyle'
+  title='Samewave styleguide'
   subtitle='Living Style Guide'
   }}
+
+  {{#freestyle-section name="UI Elements"}}
+
+    {{#freestyle-usage "chat-box" title="Chat box"}}
+      {{chat-box classNames="chat-box"}}
+    {{/freestyle-usage}}
+
+  {{/freestyle-section}}
 
   {{#freestyle-section name='Visual Style' as |section|}}
 
@@ -19,10 +27,10 @@
 
     {{#freestyle-subsection name='Color' section=section}}
 
-      {{#freestyle-usage 'fp' title='Freestyle Palette' usageTitle='Usage'}}
+      {{#freestyle-usage 'fp' title='Samewave Palette' usageTitle='Usage'}}
         {{freestyle-palette
         colorPalette=colorPalette
-        title='Dummy App Color Palette'
+        title='Color Palette'
         description='This component displays the color palette specified in freestyle/palette.json'
         }}
       {{/freestyle-usage}}

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,8 @@
   "dependencies": {
     "ember": "~2.7.0",
     "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0"
+    "ember-qunit-notifications": "0.1.0",
+    "remarkable": "1.6.2",
+    "highlightjs": "9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cordova-keyboard": "0.0.1",
     "ember-data": "^2.7.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-freestyle": "0.2.13",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-simple-auth": "1.1.0",


### PR DESCRIPTION
Add a living styleguide to the app which can be view at [http://localhost:4200/#/freestyle](http://localhost:4200/#/freestyle)

> Ember Freestyle is an Ember addon that allows you to quickly create a living styleguide for your Ember app. Whereas other living style guide projects showcase current CSS using dummy HTML, Ember Freestyle presents existing Ember components from your app in a dedicated living style guide.