### PR TITLE
Add header to root loading route

### DIFF
--- a/app/loading/template.hbs
+++ b/app/loading/template.hbs
@@ -1,3 +1,24 @@
-<section class="c-loading-page">
-	{{inline-svg 'images/icons/icon-loading' class="c-loading-page_icon"}}
-</section>
+<header class="pink || l-app-header">
+  <div class="c-header is-disabled">
+    <section class="c-header_first-section">
+      {{inline-svg "images/icons/icon-back" class="c-icon--back"}}
+    </section>
+
+    <section class="c-header_second-section">
+      <h1 class="c-header_title">
+        loading
+      </h1>
+    </section>
+
+
+    <section class="c-header_last-section">
+      {{inline-svg "images/icons/icon-logout" class="c-icon--logout"}}
+    </section>
+  </div>
+</header>
+
+<div class="l-app-body">
+	<section class="c-loading-page">
+		{{inline-svg 'images/icons/icon-loading' class="c-loading-page_icon"}}
+	</section>
+</div>


### PR DESCRIPTION
Now there is a header while the root loading is present, but note that the buttons will not work. Should probably make them grey