### PR TITLE
Fix cursor chat box

### DIFF
--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,2 +1,3 @@
-
 {{outlet}}
+
+<div id="ios-keyboard-push" class="c-ios-keyboard-push"></div>

--- a/app/stream/index/chat/controller.js
+++ b/app/stream/index/chat/controller.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { animate } from 'liquid-fire';
 
 const {
   Controller,
@@ -7,9 +8,6 @@ const {
   observer,
   run,
   computed,
-  computed: {
-    alias
-  },
   isEmpty
 } = Ember;
 
@@ -39,8 +37,7 @@ export default Controller.extend({
 
   didRender() {
     this.commentsElement = $('.js-comments-section');
-    this.chatBox = $('.js-chat-box');
-    this.streamBody = $('.js-stream-body');
+    this.$keyboardPusher = $('#ios-keyboard-push');
     this.scrollToBottom();
 
     if (window.Keyboard) {
@@ -52,6 +49,11 @@ export default Controller.extend({
 
     this.showNewMessagesMarker();
 
+  },
+
+  keyboardPusherOptions: {
+    duration: 150,
+    easing: 'ease-in-out'
   },
 
   showNewMessagesMarker() {
@@ -138,26 +140,15 @@ export default Controller.extend({
       scrollHeight
     } = this.commentsElement.get(0);
 
-    this.streamBody.css({
-      'transform': `translateY(-${height}px)`,
-      '-webkit-transform': `translateY(-${height}px)`
-    });
-
-    // We need a run later so that scrollTop is only set after keyboard shows
-    run.later(this, () => {
-      this.commentsElement.scrollTop(scrollHeight + height);
-
+    animate(this.$keyboardPusher, { height }, this.get('keyboardPusherOptions'), 'keyboard-animation').then(() => {
       this.commentsElement.animate({
         scrollTop: scrollHeight + height
-      }, 100);
-    }, 120);
+      }, 200);
+    });
   },
 
   hideKeyboard() {
-    this.streamBody.css({
-      'transform': 'translateY(-0px)',
-      '-webkit-transform': 'translateY(-0px)'
-    });
+    animate(this.$keyboardPusher, { height: 0 }, this.get('keyboardPusherOptions'), 'keyboard-animation');
   },
 
   // For development only

--- a/app/stream/index/chat/controller.js
+++ b/app/stream/index/chat/controller.js
@@ -136,6 +136,10 @@ export default Controller.extend({
   },
 
   showKeyboard(height) {
+    if (window.cordova.platformId !== 'ios') {
+      return;
+    }
+
     let {
       scrollHeight
     } = this.commentsElement.get(0);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -43,6 +43,7 @@
 @import 'components/comments-section';
 @import 'components/unread-notifier';
 @import 'components/load-earlier';
+@import 'components/keyboard-push';
 
 // Objects
 @import 'objects/ribbon';

--- a/app/styles/components/_comments-section.scss
+++ b/app/styles/components/_comments-section.scss
@@ -5,6 +5,8 @@
   overflow-y: scroll;	
   cursor: pointer;
   -webkit-overflow-scrolling: touch;
+  will-change: height, scroll-position;
+  transform: height $speed-fast;
 
 	// NOTE: Trick to get IOS over-scroll working when there is one comment
 	&::before {

--- a/app/styles/components/_keyboard-push.scss
+++ b/app/styles/components/_keyboard-push.scss
@@ -1,0 +1,4 @@
+.c-ios-keyboard-push {
+	flex: 0 0 auto;
+	background-color: map-get($colours, 'pink');
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/130607553

https://www.pivotaltracker.com/story/show/130616927

https://www.pivotaltracker.com/story/show/130616929

Cursor was losing it's place due to the input field been translated up. Now the comment box gets smaller instead of moving.